### PR TITLE
pillar: hardware: Read SoC serial number from sysfs

### DIFF
--- a/pkg/pillar/hardware/model.go
+++ b/pkg/pillar/hardware/model.go
@@ -30,6 +30,7 @@ import (
 const (
 	compatibleFile    = "/proc/device-tree/compatible"
 	cpuInfoFile       = "/proc/cpuinfo"
+	socSerialFile     = "/sys/devices/soc0/serial_number"
 	modelOverrideFile = types.PersistStatusDir + "/hardwaremodel"
 	softSerialFile    = types.IdentityDirname + "/soft_serial"
 )
@@ -139,6 +140,14 @@ func getCPUSerial(log *base.LogObject) string {
 			}
 		}
 	}
+	if serial == "" {
+		if _, err := os.Stat(socSerialFile); err == nil {
+			contents, err := ioutil.ReadFile(socSerialFile)
+			if err == nil {
+				serial = strings.TrimSuffix(string(contents), "\n")
+			}
+		}
+	}
 	return serial
 }
 
@@ -171,8 +180,9 @@ func GetProductSerial(log *base.LogObject) string {
 			err)
 		serial = []byte{}
 	}
-	if string(serial) != "" {
-		return strings.TrimSuffix(string(serial), "\n")
+	strserial := strings.TrimSuffix(string(serial), "\n")
+	if strserial != "" && strserial != "Not Specified" {
+		return strserial
 	} else {
 		return getCPUSerial(log)
 	}


### PR DESCRIPTION
SoC platform driver exports SoC unique serial number through sysfs, which usually can be read in /sys/devices/soc0/serial_number. Pillar doesn't consider this resource to look at it for device's serial number.

This commit does the following:

- Adds /sys/devices/soc0/serial_number as a resource to look at it for device's serial number

- Fixes checking of dmidecode result: Pillar uses primarily dmidecode to find device's serial number. If no serial number is found, dmidecode can return the "Not Specified" string, instead of null. If "" or "Not Specified" is returned, call getCPUSerial() to look into auxiliary resources.

Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>