### PR TITLE
.github: Add workflow to allow CI rerun via PR comment.

### DIFF
--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -1,0 +1,73 @@
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Rerun CI on /rerun-ci
+
+on:  # yamllint disable-line rule:truthy
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun-failed:
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/rerun-ci')
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: write
+      issues: read
+      pull-requests: read
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Parse CODEOWNERS to get allowed users
+        run: |
+          CODEOWNERS=".github/CODEOWNERS"
+          awk '{for(i=1;i<=NF;i++) if($i ~ /^@/) print substr($i,2)}' "$CODEOWNERS" | sort -u > allowed_users.txt
+
+      - name: Check if comment author is allowed
+        run: |
+          COMMENT_USER="${{ github.event.comment.user.login }}"
+          echo "User: $COMMENT_USER"
+          if ! grep -Fxq "$COMMENT_USER" allowed_users.txt; then
+            echo "User $COMMENT_USER is not allowed to rerun CI." >&2
+            exit 1
+          fi
+
+      - name: Find failed workflow runs for this PR
+        id: get_runs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number }}"
+          REPO="${{ github.repository }}"
+          PR_DATA=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER")
+          BRANCH=$(echo "$PR_DATA" | jq -r '.head.ref')
+          RUNS_URL="https://api.github.com/repos/$REPO/actions/runs?event=pull_request&branch=$BRANCH"
+          RUNS=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" "$RUNS_URL")
+          RUN_IDS=$(echo "$RUNS" | jq -r '.workflow_runs[] | select(.pull_requests[].number=='"$PR_NUMBER"') | select(.conclusion != null and .conclusion != "success") | .id')
+          echo "$RUN_IDS" > run_ids.txt
+          if [ -z "$RUN_IDS" ]; then
+            echo "No failed workflow runs found for this PR"
+            echo "has_runs=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_runs=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Re-run failed workflow runs
+        if: steps.get_runs.outputs.has_runs == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          while read -r run_id; do
+            [ -z "$run_id" ] && continue
+            echo "Re-running workflow run $run_id"
+            curl -sSL -X POST -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/actions/runs/$run_id/rerun"
+          done < run_ids.txt


### PR DESCRIPTION
# Description

Introduce a GitHub Actions workflow that enables authorized users to trigger a CI rerun by commenting /rerun-ci on a pull request. The workflow verifies the commenter against the list in CODEOWNERS before proceeding. It identifies failed workflow runs for the PR and attempts to rerun them. This aims to streamline CI management and restricts rerun capabilities to approved users, improving security and workflow efficiency.

## PR dependencies

None.

## How to test and validate this PR

This change is a workflow change, so no need to verify by the SysTest team.

Here I describe how it is expected to work.

1. Open or create a pull request in the repository.
2. Ensure your GitHub username is listed in `.github/CODEOWNERS`.
3. Trigger a workflow run and allow at least one job to fail (you may need to use a draft PR for testing).
4. Comment `/rerun-ci` on the pull request.
5. Verify that the workflow is triggered and only runs for users allowed in `CODEOWNERS`.
6. Confirm that any failed workflow runs for the PR are retried.
7. If a user not listed in `CODEOWNERS` comments `/rerun-ci`, the workflow should not rerun any jobs and should exit with an error.

This change is covered by the new workflow logic and can be observed through the Actions tab in the GitHub interface.

## Changelog notes

None. Not user-seen changes.

## PR Backports

- 14.5-stable: No
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

