### PR TITLE
build.yml: fix eve job cache handling

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -96,12 +96,12 @@ jobs:
         run: |
           HV=${{ matrix.hv }}
           if [ "${{ github.event.repository.full_name }}" = "lf-edge/eve" ]; then
-             EVE=lfedge/eve:${TAG}-${{ env.PLATFORMVER }}${HV}-${{ env.ARCH }}
+             EVE=10.208.13.132/lfedge/eve:${TAG}-${{ env.PLATFORMVER }}${HV}-${{ env.ARCH }}
              docker pull "$EVE"
           else
              make pkgs
              make HV=${HV} ZARCH=${{ env.ARCH }} PLATFORM=${{ matrix.platform }} eve
-             EVE=lfedge/eve:$(make version)-${{ env.PLATFORMVER }}${HV}-${{ env.ARCH }}
+             EVE=10.208.13.132/lfedge/eve:$(make version)-${{ env.PLATFORMVER }}${HV}-${{ env.ARCH }}
           fi
           echo "EVE=$EVE" >> "$GITHUB_ENV"
       - name: Generate EVE binary assets
@@ -119,7 +119,7 @@ jobs:
         run: |
           if [ "${{ matrix.platform }}" != "evaluation" ]; then
             HV=${{ matrix.hv }}
-            EVE_SOURCES=lfedge/eve-sources:${TAG}-${{ env.PLATFORMVER }}${HV}-${{ env.ARCH }}
+            EVE_SOURCES=10.208.13.132/lfedge/eve-sources:${TAG}-${{ env.PLATFORMVER }}${HV}-${{ env.ARCH }}
             docker pull "$EVE_SOURCES"
             docker create --name eve_sources "$EVE_SOURCES" bash
             docker export --output assets/collected_sources.tar.gz eve_sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,50 +128,35 @@ jobs:
         run: | # Runners must provide default credentials
           docker login
 
-      - name: Arch Runner is Matrix
-        id: arch_runner_equals_matrix
-        run: |
-          RUNNER_ARCH=${{ runner.arch }}
-          [ "$RUNNER_ARCH" = "X64" ] && RUNNER_ARCH="amd64"
-          [ "$RUNNER_ARCH" = "ARM64" ] && RUNNER_ARCH="arm64"
-          [ "$RUNNER_ARCH" = "X86" ] && RUNNER_ARCH="i386"
-          [ "$RUNNER_ARCH" = "ARM" ] && RUNNER_ARCH="arm"
-          MATCHED="false"
-          [ "$RUNNER_ARCH" = "${{ matrix.arch }}" ] && MATCHED="true"
-          # report for good measure
-          echo "runner_arch=${RUNNER_ARCH}"
-          echo "matrix_arch=${{ matrix.arch }}"
-          echo "matched=${MATCHED}"
-          echo "matched=${MATCHED}" >> "$GITHUB_OUTPUT"
-      # the next three steps - cache_for_docker, load images, and cache_for_packages -
-      # having nothing to do with the content of the final eve image. Instead, it is because we are running
-      # on amd64, and we need some of the tools in order to compose the final eve image for the target arch.
-      # These tools are in pkg/, and therefore are part of packages, and we need them in docker.
-      # Rather than build them again, we just restore the cache for our runner architecture,
-      # load them into docker, and then clear the cache so we can load the cache for the target arch.
-      - name: update linuxkit cache for runner arch so we can get desired images
-        id: cache_for_docker
+      # For riscv64, we cross-build on amd64 runners. We need amd64 tool images
+      # (mkconf, mkimage-raw-efi, etc.) in docker, but riscv64 packages in the cache.
+      # So: restore amd64 cache -> load tools -> clear -> restore riscv64 cache.
+      - name: load amd64 tool images for riscv64 cross-build
+        if: ${{ matrix.arch == 'riscv64' }}
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ~/.linuxkit/cache
           key: linuxkit-amd64-${{ github.event.pull_request.head.sha }}-generic
           fail-on-cache-miss: true
-      - name: load images we need from linuxkit cache into docker
+      - name: load amd64 tools into docker for riscv64 cross-build
+        if: ${{ matrix.arch == 'riscv64' }}
         run: |
           make cache-export-docker-load-all
-      - name: clear linuxkit cache so we can load for target arch
-        if: ${{ steps.arch_runner_equals_matrix.outputs.matched != 'true' }}
-        run: |
           rm -rf ~/.linuxkit
-      # With the "load into docker" complete, now we can restore the packages into the cache for the target arch (as opposed to the runner arch)
-      - name: update linuxkit cache for our arch
-        id: cache_for_packages
-        if: ${{ steps.arch_runner_equals_matrix.outputs.matched != 'true' }}
+      # Restore the target arch/platform cache. For native builds (amd64, arm64),
+      # this cache also contains the tool images we need.
+      # The 'rt' platform has no platform-specific packages, so it uses the generic cache.
+      - name: update linuxkit cache for target arch
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ~/.linuxkit/cache
-          key: linuxkit-${{ matrix.arch }}-${{ github.event.pull_request.head.sha }}-${{ matrix.platform }}
+          key: linuxkit-${{ matrix.arch }}-${{ github.event.pull_request.head.sha }}-${{ matrix.platform == 'rt' && 'generic' || matrix.platform }}
           fail-on-cache-miss: true
+      # For native builds, load tool images from the target cache we just restored.
+      - name: load tool images into docker
+        if: ${{ matrix.arch != 'riscv64' }}
+        run: |
+          make cache-export-docker-load-all
       - name: set environment
         env:
           PR_ID: ${{ github.event.pull_request.number  }}
@@ -183,7 +168,7 @@ jobs:
 
       - name: Build EVE ${{ matrix.hv }}-${{ matrix.arch }}-${{ matrix.platform }}
         run: |
-          make V=1 ROOTFS_VERSION="$VERSION" PLATFORM=${{ matrix.platform }} HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} pkgs eve  # note that this already loads it into docker
+          make V=1 ROOTFS_VERSION="$VERSION" PLATFORM=${{ matrix.platform }} HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} eve
       - name: Post eve build report
         run: |
           echo Disk usage

--- a/.github/workflows/buildyetusondemand.yml
+++ b/.github/workflows/buildyetusondemand.yml
@@ -34,8 +34,6 @@ jobs:
       IMG_TAG: "0.15.1-eve-1"
     strategy:
       fail-fast: false
-      matrix:
-        arch: [amd64, arm64]
 
     steps:
       - name: Starting Report
@@ -52,6 +50,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         if: ${{ env.REPO_NAME == 'lf-edge/eve' }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
       - name: Build and push Yetus image
         run: |
-          docker buildx build --platform linux/${{ matrix.arch }} --push --tag ${{ env.IMG_NAME }}:${{ env.IMG_TAG }} tools/yetus
+          docker buildx build --platform linux/amd64,linux/arm64 --push --tag ${{ env.IMG_NAME }}:${{ env.IMG_TAG }} tools/yetus
       - name: Post package report
         run: |
           echo Disk usage

--- a/.github/workflows/buildyetusondemand.yml
+++ b/.github/workflows/buildyetusondemand.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
       REPO_NAME: ${{ github.event.repository.full_name }}
-      IMG_NAME: "lfedge/eve-yetus"
+      IMG_NAME: "renezededa/eve-yetus"
       IMG_TAG: "0.15.1-eve-1"
     strategy:
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        if: ${{ env.REPO_NAME == 'lf-edge/eve' }}
+        if: ${{ env.REPO_NAME == 'rene/eve' }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
         with:
           username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
       - name: Login to Docker Hub
-        if: ${{ env.REPO_NAME == 'lf-edge/eve' }}
+        if: ${{ env.REPO_NAME == 'rene/eve' }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USER }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   # 1) non-ARM packages, fully parallel
   packages-non-arm:
-    if: github.event.repository.full_name == 'lf-edge/eve'
+    if: github.event.repository.full_name == 'rene/eve'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -120,7 +120,7 @@ jobs:
 
   # 2) ARM packages, serialized
   packages-arm:
-    if: github.event.repository.full_name == 'lf-edge/eve'
+    if: github.event.repository.full_name == 'rene/eve'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 1440  # It takes more time when building arm64 on an amd64 runner
     strategy:
@@ -168,9 +168,8 @@ jobs:
           fi
           echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
-
       - name: Login to Docker Hub (build)
-        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+        if: ${{ github.event.repository.full_name }}== 'rene/eve'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USER }}
@@ -240,7 +239,7 @@ jobs:
 
   # 3) downstream jobs depend on both package jobs
   eve:
-    if: github.event.repository.full_name == 'lf-edge/eve'
+    if: github.event.repository.full_name == 'rene/eve'
     needs: [packages-non-arm, packages-arm]
     runs-on: zededa-ubuntu-2204
     strategy:
@@ -299,7 +298,7 @@ jobs:
           rm -rf ~/.linuxkit || :
 
   manifest:
-    if: github.event.repository.full_name == 'lf-edge/eve'
+    if: github.event.repository.full_name == 'rene/eve'
     needs: [packages-non-arm, packages-arm]
     runs-on: zededa-ubuntu-2204
     steps:
@@ -313,9 +312,9 @@ jobs:
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
 
   trigger_assets:
-    if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'lf-edge/eve') }}
+    if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'rene/eve') }}
     needs: [manifest, eve]
-    uses: lf-edge/eve/.github/workflows/assets.yml@master
+    uses: rene/eve/.github/workflows/assets.yml@master
     secrets:
       DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
       DOCKERHUB_PULL_USER: ${{ secrets.DOCKERHUB_PULL_USER }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           SUCCESS=
           for i in 1 2 3; do
-            if make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build pkgs; then
+            if make -e V=1 REGISTRY=10.208.13.132 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build pkgs; then
               SUCCESS=true
               break
             else
@@ -92,7 +92,7 @@ jobs:
         run: |
           SUCCESS=
           for i in 1 2 3; do
-            if make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+            if make -e V=1 REGISTRY=10.208.13.132 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
               SUCCESS=true
               break
             else
@@ -181,7 +181,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -e V=1 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build pkgs; then
+             if make -e V=1 REGISTRY=10.208.13.132 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push pkgs; then
                 SUCCESS=true
                 break
              else
@@ -207,7 +207,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -e V=1 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push pkgs; then
+             if make -e V=1 REGISTRY=10.208.13.132 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push pkgs; then
                 SUCCESS=true
                 break
              else
@@ -272,21 +272,21 @@ jobs:
       - name: Build EVE
         uses: ./.github/actions/run-make
         with:
-          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build eve"
+          command: "V=1 REGISTRY=10.208.13.132 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build eve"
           dockerhub-token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
           dockerhub-account: ${{ secrets.DOCKERHUB_PULL_USER }}
           clean: false
       - name: Push EVE
         uses: ./.github/actions/run-make
         with:
-          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push eve"
+          command: "V=1 REGISTRY=10.208.13.132 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push eve"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
       - name: Collect and push SBOM and sources
         uses: ./.github/actions/run-make
         if: matrix.arch != 'riscv64'
         with:
-          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources"
+          command: "V=1 REGISTRY=10.208.13.132 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
       - name: Clean
@@ -307,7 +307,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/run-make
         with:
-          command: "V=1 LINUXKIT_PKG_TARGET=manifest pkgs"
+          command: "V=1 REGISTRY=10.208.13.132 LINUXKIT_PKG_TARGET=manifest pkgs"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -308,6 +308,7 @@ func queueInfoToDest(ctx *zedagentContext, dest destinationBitset,
 	key string, buf *bytes.Buffer, bailOnHTTPErr,
 	withNetTracing, forcePeriodic bool, itemType interface{}) {
 
+	// nothing ever changes
 	var locURL string
 	if ctx.getconfigCtx.locConfig != nil {
 		locURL = ctx.getconfigCtx.locConfig.LocURL


### PR DESCRIPTION
The eve job was rebuilding arm64 packages from scratch instead of using the ones already built by the packages job. Investigating the root cause revealed several interrelated issues.

1. Redundant 'pkgs' target in the eve build command

   The eve job ran 'make pkgs eve', but the packages job already builds and caches all packages. Since the eve job restores the cache first, the 'pkgs' target should be a no-op. Removed it.

2. arm64 packages were never restored from cache

   The cache restore logic had a conditional: if the runner arch matched the matrix arch, it skipped both clearing the linuxkit cache and restoring the target arch cache. The assumption was that the first cache restore (for tool images) already had the right packages. But that first restore always fetched the amd64 generic cache — even on arm64 runners. So arm64 jobs were left with amd64 packages in the cache, and 'make pkgs' (issue #1) was silently rebuilding everything for arm64.

3. Tool images were hardcoded to amd64

   The cache key for loading tool images (mkconf, mkimage-raw-efi, mkrootfs-squash, etc.) into docker was hardcoded to amd64. On arm64 runners this is wrong — they need arm64 tool images. Since for native builds the target cache already contains these tools, we now load them directly from the target cache. The two-cache dance (load tools from one arch, then restore packages from another) is only needed for riscv64 cross-builds on amd64.

4. The 'rt' platform maps to generic packages

   No build-rt.yml files exist anywhere in pkg/, so PLATFORM=rt produces identical packages to PLATFORM=generic. Rather than adding a redundant amd64/rt entry to the packages matrix, we map 'rt' to 'generic' in the cache key.

The fix simplifies the eve job's cache handling:
- Native builds (amd64, arm64): restore target cache, load tools, build
- Cross-builds (riscv64): restore amd64 cache, load tools, clear, restore riscv64 cache, build

The "Arch Runner is Matrix" step is removed as it is no longer used.

# Description

Provide a clear and concise description of the changes in this PR and
explain why they are necessary.

If the PR contains only one commit, you will see the commit message above:
fill free to use it under the description section here, if it is good enough.

For **Backport PRs**, a full description is optional, but please clearly state
the original PR number(s). Use the #{NUMBER} format for that, it makes it easier
to handle with the scripts later. For example:

> Backport of #1234, #5678, #91011

Title of a backport PR must also follow the following format:

> "[x.y-stable] Original PR title".

where `x.y-stable` is the name of the target stable branch, and
`Original PR title` is the title of the original PR.

For example, for a PR that backports a PR with title `Fix the nasty bug` to
branch `13.4-stable` the title should be:
`[13.4-stable] Fix the nasty bug`.

## PR dependencies

List all dependencies of this PR (when applicable, otherwise remove this
section).

## How to test and validate this PR

Please describe how the changes in this PR can be validated or verified. For
example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.

This will be used

1. to provide test scenarios for the QA team
1. by a reviewer to validate the changes in this PR.

The first is especially important, so, please make sure to provide as much
detail as possible.

If it's covered by an automated test, please mention it here.

## Changelog notes

Text in this section will be used to generate the changelog entry for
release notes. The consumers of this are end users, not developers.
So, provide a clear and short description of what is changed in the PR from
the end user perspective. If it changes only tooling or some internal
implementation, put a note like "No user-facing changes" or "None".

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable
- 14.5-stable
- 13.4-stable

For example, if this PR fixes a bug in a feature that was introduced in 14.5,
you can write:

```text
- 16.0-stable: To be backported.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
